### PR TITLE
Always get the biggest available version in current branch when tagging

### DIFF
--- a/tag.py
+++ b/tag.py
@@ -1,12 +1,14 @@
 import os, sys, re
 
+VERSION_REGEX = r'v[0-9]+\.[0-9]+\.[0-9]+'
+
 def isValidTag(tag):
 	if tag is None:
 		return False
 	if tag == "":
 		return False
 
-	regex = re.compile(r'v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$')
+	regex = re.compile(VERSION_REGEX)
 	if regex.match(tag):
 		return True
 
@@ -22,10 +24,16 @@ def versionTuple(v):
 	return version
 
 def versionTupleToString(v):
-	return "v" + str(v[0]) + "." + str(v[1]) + "." + str(v[2])
+	return "v{}.{}.{}".format(v[0], v[1], v[2])
 
-def scanAllTagsAndGetBiggestVersion():
-	all_tags = os.popen("git tag").read().split("\n")
+def scanCurrentBranchTagsAndGetBiggestVersion():
+	log_for_current_branch = os.popen('git log --decorate --pretty=oneline').read()
+	all_tags = []
+	log_tag_version_regex = r'tag: ({})'.format(VERSION_REGEX)
+	for line in log_for_current_branch.split("\n"):
+		for match in re.finditer(log_tag_version_regex, line):
+			all_tags.append(match.group(1))
+
 	biggest_tag_version = None
 	for tag in all_tags:
 		if isValidTag(tag):
@@ -34,31 +42,31 @@ def scanAllTagsAndGetBiggestVersion():
 				biggest_tag_version = tag_version
 	return biggest_tag_version
 
-def getVersionTagForCurrentBranch():
+def getBiggestVersionTagForCurrentBranch():
 	last_tag = os.popen("git describe --abbrev=0 --tags").read().replace("\n", "")
 	if not isValidTag(last_tag):
 		raise ValueError('Cannot read the last tag version. Please use a valid tag format (v1.2.3) for the last tagged commit in current branch')
 
 	current_version = versionTuple(last_tag)
-	biggest_version = scanAllTagsAndGetBiggestVersion()
-	if biggest_version is None:
-		raise ValueError('Cannot read any tag from current repo.')
+	biggest_version_for_branch = scanCurrentBranchTagsAndGetBiggestVersion()
+	if biggest_version_for_branch is None:
+		raise ValueError('Cannot read any tag from current branch.')
 
-	if current_version != biggest_version:
-		print "WARNING: The latest tag (" + last_tag + ") is not the biggest version (" + versionTupleToString(biggest_version) + ")"
-	
-	return current_version
+	if current_version != biggest_version_for_branch:
+		print "WARNING: The latest tag ({}) is not the biggest version in branch ({}). Using biggest version.".format(last_tag, versionTupleToString(biggest_version_for_branch))
 
-def createNewTagOnCurrentHeadIfNotTagged(current_tag, new_tag): 
+	return biggest_version_for_branch
+
+def createNewTagOnCurrentHeadIfNotTagged(current_tag, new_tag):
 	tag_in_head = os.popen("git tag --contains HEAD").read().replace("\n", "")
 	if tag_in_head != "":
-		print 'No new tag. HEAD already tagged as ' + tag_in_head
+		print 'No new tag. HEAD already tagged as {}'.format(tag_in_head)
 	else:
-		print "Creating new tag: " + new_tag + " (previous tag for branch: " + current_tag + ")"
-		os.popen("git tag " + new_tag + " HEAD")
+		print "Creating new tag: {} (previous tag for branch: {})".format(new_tag, current_tag)
+		os.popen("git tag {} HEAD".format(new_tag))
 
 
 #run!
-current_tag = getVersionTagForCurrentBranch()
+current_tag = getBiggestVersionTagForCurrentBranch()
 new_version_tag = (current_tag[0], current_tag[1], current_tag[2] + 1)
 createNewTagOnCurrentHeadIfNotTagged(versionTupleToString(current_tag), versionTupleToString(new_version_tag))


### PR DESCRIPTION
The current version of tag-flow has an issue where the script does not use the biggest version in the current branch after mixing different version tags in the same branch.

Here is an example: using git-flow, we merge a master branch that includes versioned hotfixes (e.g.: v1.1.x) into a develop branch which is in a bigger version (e.g.: v1.2.x). If the latest merged commit in develop has a v1.1.x tag, tag-flow will increment the version number using the v1.1.x tag instead of the v1.2.x tag.

This commit fixes this by scanning the current branch's tags and then selecting the biggest one to increment the tag.

I also changed a few things in the script to make it a bit more pythonic and removed some redundant stuff.
